### PR TITLE
clean using cleanWs() and explicitly set GOPATH for tests

### DIFF
--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -33,6 +33,11 @@ pipeline {
           args '--entrypoint=""' /* allows jenkins use cat */
         }
       }
+      environment {
+        GOCACHE = "off"
+        GOPATH  = "${env.WORKSPACE}"
+        PATH    = "${env.PATH}:${env.GOPATH}/bin"
+      }
       options {
         checkoutToSubdirectory('src/github.com/status-im/keycard-cli')
       }
@@ -66,10 +71,8 @@ pipeline {
     }
   }
   post {
-    always { script {
-      dir(env.PROJECT) {
-        sh 'make clean'
-      }
-    } }
+    always { 
+      cleanWs() /* we can't use `make clean` because xgo creates root files */
+    }
   }
 }

--- a/_assets/ci/Jenkinsfile.pr
+++ b/_assets/ci/Jenkinsfile.pr
@@ -51,10 +51,10 @@ pipeline {
     }
   }
   post {
-    always { script {
+    always {
       dir(env.PROJECT) {
         sh 'make clean'
       }
-    } }
+    }
   }
 }


### PR DESCRIPTION
The `cleanWs()` method which comes from the [ws-cleanup](https://jenkins.io/doc/pipeline/steps/ws-cleanup/) plugin doesn't give a shit about permissions and just deletes the whole workspace, so we can remove binaries generated by `xgo` inside of `build/bin` even if they are owned by root due to being created in a Docker container.