### PR TITLE
Export Key (And Shell Documentation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.DS_Store
+keycard-cli
 /build
 *.cap

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ export GO_PROJECT_PATH ?= github.com/$(GITHUB_USER)/$(GITHUB_REPO)
 deps:
 	go get github.com/karalabe/xgo
 	go get github.com/aktau/github-release
+	go get github.com/status-im/keycard-go
 
 build:
 	go build -i -o $(GOBIN)/$(BIN_NAME) -v .

--- a/README.md
+++ b/README.md
@@ -84,4 +84,28 @@ keycard-cli delete -l debug
 ```
 
 ### Keycard shell
-TODO
+
+The shell can be used to interact with the KeyCard using `keycard-go`. You can start the shell with:
+
+```
+keycard-cli shell
+```
+
+Once in the shell, you may submit one command at a time, followed by Enter.
+
+### Pairing
+
+Before pairing, you need to initialize your card. You can do this interactively in the shell or using `keycard init` specified in the above section.
+
+> Once you initialize your card, **save the PIN, PUK, and Pairing Password fields that are generated**; you will need these to pair with the card. These secrets cannot be set once the card is initialized. If you lose them, you will need to delete the app and reinstall it using the instructions in previous sections.
+
+With the secrets in hand, run the following commands in the shell:
+
+```
+> keycard-select
+> keycard-set-secrets <PIN> <PUK> <PairingPassword>
+> keycard-pair
+```
+
+If you don't get an error message, it means you have paired with the card!
+

--- a/README.md
+++ b/README.md
@@ -159,3 +159,11 @@ Example:
 ```
 
 Where `RESPONSE_KEY` is an EC public key on the secp256k1 curve in uncompressed point format, i.e. `04{X-component}{Y-component}`.
+
+#### Signing
+
+TODO
+
+#### Other Functionality
+
+TODO

--- a/main.go
+++ b/main.go
@@ -311,7 +311,11 @@ func commandStatus(card *scard.Card) error {
 
 func commandShell(card *scard.Card) error {
 	fi, _ := os.Stdin.Stat()
-	if (fi.Mode() & os.ModeCharDevice) == 0 {
+	// Alex: I don't understand what the intention is here, but the condition
+	// breaks for me. I'm also guessing the error message doesn't totally
+	// capture the failing condition. 
+	// if (fi.Mode() & os.ModeCharDevice) == 0 {
+	if (fi.Mode() & os.ModeCharDevice) == os.ModeCharDevice {
 		s := NewShell(card)
 		return s.Run()
 	} else {

--- a/shell.go
+++ b/shell.go
@@ -112,7 +112,6 @@ func NewShell(t keycardio.Transmitter) *Shell {
 
 	tplFuncs := &TemplateFuncs{s}
 	s.tplFuncMap = tplFuncs.FuncMap()
-
 	s.commands = map[string]shellCommand{
 		"echo":                          s.commandEcho,
 		"gp-send-apdu":                  s.commandGPSendAPDU,
@@ -154,15 +153,14 @@ func (s *Shell) flushOut() {
 }
 
 func (s *Shell) Run() error {
+	fmt.Println("Welcome to the KeyCard CLI Shell. Please type your commands and hit Enter:")
 	reader := bufio.NewReader(os.Stdin)
 	defer s.flushOut()
-
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			break
 		}
-
 		err = s.evalLine(line)
 		if err != nil {
 			return err
@@ -319,7 +317,6 @@ func (s *Shell) commandKeycardInit(args ...string) error {
 	if s.kCmdSet.ApplicationInfo.Initialized {
 		return errCardAlreadyInitialized
 	}
-
 	if s.Secrets == nil {
 		secrets, err := keycard.GenerateSecrets()
 		if err != nil {
@@ -348,9 +345,7 @@ func (s *Shell) commandKeycardSetSecrets(args ...string) error {
 	if err := s.requireArgs(args, 3); err != nil {
 		return err
 	}
-
 	s.Secrets = keycard.NewSecrets(args[0], args[1], args[2])
-
 	return nil
 }
 


### PR DESCRIPTION
* Adds an interface to the SDK's Export Key function (implemented [here](https://github.com/status-im/keycard-go/pull/4)).
* Adds documentation to shell

> Note that I had to comment out a check in `main.go`. I added a comment, as I wasn't sure what the check was trying to accomplish, but it was blocking usage of the shell and removing it doesn't seem to affect functionality.