### PR TITLE
ci: use crazymax/xgo:1.18.1 docker image as base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,19 @@ VERSION = $(shell cat VERSION)
 export GITHUB_USER ?= status-im
 export GITHUB_REPO ?= $(PROJECT_NAME)
 
-export IMAGE_TAG   ?= latest
+export IMAGE_TAG   ?= xgo-1.18.1
 export IMAGE_NAME  ?= statusteam/keycard-cli-ci:$(IMAGE_TAG)
 
 export GO_PROJECT_PATH ?= github.com/$(GITHUB_USER)/$(GITHUB_REPO)
 
-deps:
+deps: install-xgo install-github-release
 	go version
-	go install github.com/karalabe/xgo@latest
-	go install github.com/aktau/github-release@latest
+
+install-xgo:
+	go install github.com/crazy-max/xgo@v0.23.0
+
+install-github-release:
+	go install github.com/aktau/github-release@v0.10.0
 
 build:
 	go build -o $(GOBIN)/$(BIN_NAME) -v -ldflags "-X main.version=$(VERSION)" .
@@ -35,10 +39,10 @@ docker-image:
 
 build-platforms:
 	xgo \
-		-ldflags "-X main.version=$(VERSION)" \
-		-out $(BIN_NAME) \
-		-dest $(GOBIN) \
-		-image $(IMAGE_NAME) \
+		-ldflags="-X main.version=$(VERSION)" \
+		-out=$(BIN_NAME) \
+		-dest=$(GOBIN) \
+		-docker-image=$(IMAGE_NAME) \
 		-targets=$(XGO_TARGETS) .
 
 release:

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -13,14 +13,14 @@ pipeline {
   }
 
   environment {
-    PROJECT = 'src/github.com/status-im/keycard-cli'
+    PROJECT = "${env.WORKSPACE}/src/github.com/status-im/keycard-cli"
     GOPATH  = "${env.WORKSPACE}"
     PATH    = "${env.PATH}:${env.GOPATH}/bin"
   }
 
   stages {
     stage('Prep') {
-      steps { dir(env.PROJECT) {
+      steps { dir(PROJECT) {
         sh 'make deps'
       } }
     }
@@ -29,7 +29,7 @@ pipeline {
       agent {
         docker {
           label 'linux'
-          image 'statusteam/keycard-cli-ci:latest'
+          image 'statusteam/keycard-cli-ci:xgo-1.18.1'
           args '--entrypoint=""' /* allows jenkins use cat */
         }
       }
@@ -40,25 +40,25 @@ pipeline {
       options {
         checkoutToSubdirectory('src/github.com/status-im/keycard-cli')
       }
-      steps { dir(env.PROJECT) {
+      steps { dir(PROJECT) {
         sh 'make test'
       } }
     }
 
     stage('Build') {
-      steps { script { dir(env.PROJECT) {
+      steps { script { dir(PROJECT) {
         sh 'make build-platforms'
       } } }
     }
 
     stage('Archive') {
-      steps { dir(env.PROJECT) {
+      steps { dir(PROJECT) {
         archiveArtifacts('build/bin/*')
       } }
     }
 
     stage('Release') {
-      steps { dir(env.PROJECT) {
+      steps { dir(PROJECT) {
         withCredentials([usernamePassword(
           credentialsId:  'status-im-auto',
           usernameVariable: 'GITHUB_USER_NAME',

--- a/_assets/ci/Jenkinsfile.pr
+++ b/_assets/ci/Jenkinsfile.pr
@@ -2,7 +2,7 @@ pipeline {
   agent {
     docker { 
       label 'linux'
-      image 'statusteam/keycard-cli-ci:latest'
+      image 'statusteam/keycard-cli-ci:xgo-1.18.1'
       args '--entrypoint=""' /* allows jenkins use cat */
     }
   }

--- a/_assets/docker/Dockerfile
+++ b/_assets/docker/Dockerfile
@@ -10,6 +10,11 @@ RUN apt-get update \
  && locale-gen ${LANG} \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Jenkins user needs a specific UID/GID to work
+RUN groupadd -g 1001 jenkins \
+ && useradd --create-home -u 1001 -g 1001 jenkins
+USER jenkins
+
 MAINTAINER Jakub Sokolowski "jakub@status.im"
 LABEL description="Image for building keycard-cli tool."
 

--- a/_assets/docker/Dockerfile
+++ b/_assets/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM karalabe/xgo-1.13.x
+ARG GO_VERSION=1.18.1
+FROM crazymax/xgo:$GO_VERSION
 
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
@@ -13,9 +14,6 @@ RUN apt-get update \
 # Jenkins user needs a specific UID/GID to work
 RUN groupadd -g 1001 jenkins \
  && useradd --create-home -u 1001 -g 1001 jenkins
-USER jenkins
 
 MAINTAINER Jakub Sokolowski "jakub@status.im"
 LABEL description="Image for building keycard-cli tool."
-
-ENTRYPOINT ["/build.sh"]

--- a/_assets/docker/Makefile
+++ b/_assets/docker/Makefile
@@ -1,11 +1,13 @@
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 GIT_ROOT = $(shell git rev-parse --show-toplevel)
 
-IMAGE_TAG  ?= latest
+GO_VERSION ?= 1.18.1
+IMAGE_TAG  ?= xgo-$(GO_VERSION)
 IMAGE_NAME ?= statusteam/keycard-cli-ci:$(IMAGE_TAG)
 
 build:
 	docker build \
+		--build-arg  "GO_VERSION=$(GO_VERSION)" \
 		--label "commit=$(GIT_COMMIT)" \
 		-t $(IMAGE_NAME) .
 


### PR DESCRIPTION
The old `xgo` image does not work:
```
# github.com/ethereum/go-ethereum/common
../../../../pkg/mod/github.com/ethereum/go-ethereum@v1.10.26/common/test_utils.go:27:18: undefined: os.ReadFile
note: module requires Go 1.17
Makefile:31: recipe for target 'test' failed
```
Appears to work: https://ci.status.im/job/status-keycard/job/keycard-cli/153/