### PR TITLE
bugfix: better handle EOF

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -171,14 +171,19 @@ func (s *Shell) Run() error {
 	defer s.flushOut()
 
 	for {
-		line, err := reader.ReadString('\n')
-		if err != nil && err != io.EOF {
+		line, readErr := reader.ReadString('\n')
+
+		if readErr != nil && readErr != io.EOF {
 			break
 		}
 
-		err = s.evalLine(line)
+		err := s.evalLine(line)
 		if err != nil {
 			return err
+		}
+
+		if readErr == io.EOF {
+			break
 		}
 	}
 


### PR DESCRIPTION
While trying to fix #29, some files were hanging after the last command and took me while to figure out why.
Following the rabbit hole I found out it had to do with `9a8018e`.
The changes are tested.